### PR TITLE
feat: add custom html attributes: `id:` `for:` `i18n:`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "@csstools/postcss-sass": "^5.1.1",
+        "acorn": "^8.12.1",
+        "acorn-walk": "^8.3.4",
         "autoprefixer": "^10.4.20",
         "cheerio": "^1.0.0",
         "cssnano": "^7.0.6",
@@ -2403,6 +2405,15 @@
       "bin": {
         "acorn": "bin/acorn"
       },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/@node-red/nodes/node_modules/acorn-walk": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz",
+      "integrity": "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==",
+      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -5607,7 +5618,6 @@
       "version": "8.12.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
       "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
-      "dev": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5625,10 +5635,12 @@
       }
     },
     "node_modules/acorn-walk": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz",
-      "integrity": "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==",
-      "dev": true,
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
       "engines": {
         "node": ">=0.4.0"
       }

--- a/package.json
+++ b/package.json
@@ -47,6 +47,8 @@
   },
   "dependencies": {
     "@csstools/postcss-sass": "^5.1.1",
+    "acorn": "^8.12.1",
+    "acorn-walk": "^8.3.4",
     "autoprefixer": "^10.4.20",
     "cheerio": "^1.0.0",
     "cssnano": "^7.0.6",

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -17,6 +17,10 @@ import autoprefixer from "autoprefixer";
 // NOTE: was not able to make @csstoll/postcss-sass work with .sass file extension => dart-sass@v1.178.0
 // import postcssSassParser from "postcss-sass";
 import cssnano from "cssnano";
+
+import * as acorn from "acorn";
+import * as acornWalk from "acorn-walk";
+
 import { type Config } from "./config.js";
 import {
   PROJECT_ROOT_DIRECTORY,
@@ -56,7 +60,106 @@ function setup() {
   logger.info("Setup complete");
 }
 
-function processHtml(buildOptions: BuildOptions, node: string): string {
+function fetchNodeCategory(node: string) {
+  const clientJsPath = path.resolve(
+    BUILDER_CLIENT_TMP_SRC_DIRECTORY,
+    "nodes",
+    node,
+    BUILDER_NODE_CLIENT_FOLDER_NAME,
+    "index.js",
+  );
+  const clientJsModule = fs.readFileSync(clientJsPath, { encoding: "utf-8" });
+  const ast = acorn.parse(clientJsModule, {
+    sourceType: "module",
+    ecmaVersion: "latest",
+  });
+
+  let category: string = "";
+  acornWalk.simple(ast, {
+    ExportDefaultDeclaration(node) {
+      if (node.declaration.type === "ObjectExpression") {
+        node.declaration.properties.forEach((prop) => {
+          if (prop.type === "Property" && prop.key.type === "Identifier") {
+            if (prop.key.name === "category") {
+              if (
+                prop.value.type === "Literal" &&
+                typeof prop.value.value === "string"
+              ) {
+                category = prop.value.value;
+              } else {
+                console.log("Category is not a simple literal:", prop.value);
+              }
+            }
+          }
+        });
+      }
+    },
+  });
+  if (!category) {
+    throw new Error(
+      "Could not identify the node's category. Please, add category attribute in the node's client javascript.",
+    );
+  }
+  return category;
+}
+
+// TODO: investigate if this could be improved if implemented with cherio parser
+async function replaceCustomHtmlAttributes(html: string, node: string) {
+  const category = fetchNodeCategory(node);
+  const inputPrefix =
+    category === "config" ? "node-config-input" : "node-input";
+
+  const pattern =
+    /(?:\s*(i18n:([a-zA-Z0-9_-]*))\s*=\s*"([^"]*)")|(?:\s*(id|for)\s*:=\s*"([^"]*)")/g;
+
+  const updatedHtml = html.replace(
+    /<([a-zA-Z][a-zA-Z0-9-_]*)\s*([^>]*)\/?>/gi,
+    (elementMatch: string, tagName: string, tagAttributes: string) => {
+      const i18nAttributes: string[] = [];
+      let newAttributes = tagAttributes;
+
+      newAttributes = newAttributes.replace(
+        pattern,
+        (
+          match: string,
+          i18nAttr: string,
+          i18nModifier: string,
+          i18nValue: string,
+          attrName: string,
+          attrValue: string,
+        ) => {
+          if (i18nAttr) {
+            i18nAttributes.push(
+              i18nModifier
+                ? `[${i18nModifier}]${node}.${i18nValue}`
+                : `${node}.${i18nValue}`,
+            );
+            return "";
+          } else if (attrName) {
+            const newValue = `${inputPrefix}-${attrValue}`;
+            return `${attrName}="${newValue}"`;
+          }
+          return match;
+        },
+      );
+
+      if (i18nAttributes.length > 0) {
+        const dataI18nAttr = `data-i18n="${i18nAttributes.join(";")}"`;
+        return `<${tagName} ${newAttributes} ${dataI18nAttr}>`;
+      }
+
+      return `<${tagName} ${newAttributes}>`;
+    },
+  );
+
+  return updatedHtml;
+}
+
+// TODO: validate html elements based on Node-RED's schema for an element, and throw an error in case there is something wrong.
+async function processHtml(
+  buildOptions: BuildOptions,
+  node: string,
+): Promise<string> {
   logger.verbose(`Processing html for node: ${node}`);
   const htmlFilePath = path.resolve(
     BUILDER_CLIENT_TMP_SRC_DIRECTORY,
@@ -66,8 +169,11 @@ function processHtml(buildOptions: BuildOptions, node: string): string {
     "index.html",
   );
   logger.verbose(`Loading html from ${htmlFilePath}`);
-  const html = fs.readFileSync(htmlFilePath, { encoding: "utf-8" });
+  let html = fs.readFileSync(htmlFilePath, { encoding: "utf-8" });
   logger.verbose("html file loaded");
+  logger.debug(html);
+  logger.verbose("replacing custom html attributes");
+  html = await replaceCustomHtmlAttributes(html, node);
   logger.debug(html);
   logger.verbose("parsing html");
   const $ = load(html, null, false);
@@ -371,7 +477,7 @@ async function bundleClient(config: Config): Promise<void> {
     await bundleJavascript(bundlerConfig);
 
     logger.verbose("Rendering client form");
-    const html = processHtml(bundlerConfig, node);
+    const html = await processHtml(bundlerConfig, node);
 
     logger.verbose("Rendering client stylesheets");
     const stylesheets = await processStylesheets(bundlerConfig, node);


### PR DESCRIPTION
These custom attributes are pre-processed at build time and converted to what Node-RED is expecting.
The goal is to make the html form more readable while less verbose. It improves maintainability.

## BEFORE
```html
<div class="form-row">
    <label for="node-config-input-instanceUrl">
      <i class="fa fa-laptop"></i>
      <span data-i18n="connection.inputs.instanceUrl">
        Instance URL
      </span>
    </label>
    <input type="text" id="node-config-input-instanceUrl" data-i18n="[placeholder]connection.inputs.placeholders.instanceUrl">
</div>
```


## AFTER

```html
<div class="form-row">
    <label for:="instanceUrl">
      <i class="fa fa-laptop"></i>
      <span i18n:="inputs.instanceUrl">
        Instance URL
      </span>
    </label>
    <input type="text" id:="instanceUrl" i18n:placeholder="inputs.placeholders.instanceUrl"/>
</div>
```

OBS: There is no validation at build time for the html elements node-red expects. 